### PR TITLE
Support for PHP 8.1 onwards and Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/http": "^9.0",
-        "spatie/laravel-mailcoach": "^5.0",
+        "php": "^8.0|^8.1|^8.2|^8.3",
+        "illuminate/http": "^9.0|^10.0",
+        "spatie/laravel-mailcoach": "^5.0|^6.0",
         "ext-openssl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Adding a PR for support for MailCoach 6, L10, and PHP ^8.1 onwards